### PR TITLE
Fix map camera state reset on screen rotation during navigation

### DIFF
--- a/CHANGELOG_ANDROID.md
+++ b/CHANGELOG_ANDROID.md
@@ -7,6 +7,10 @@
 - Add compass button to rotate map north when map is rotated
 - Group cities by region with sticky headers in city selection list
 
+### Fixed
+
+- Fix map briefly rotating to north and resetting tilt when rotating screen during navigation
+
 ### Changed
 
 - Show markers as simple colored circles when map is zoomed far out, instead of detailed icons

--- a/CHANGELOG_IOS.md
+++ b/CHANGELOG_IOS.md
@@ -14,6 +14,7 @@
 
 - Fix missing horizontal padding on title in marker info bottom sheet
 - Fix list not scrolling to selected city when it is off-screen
+- Fix map briefly rotating to north and resetting tilt when rotating screen during navigation
 
 ### Changed
 

--- a/kmp/compose/maps-compose/src/androidMain/kotlin/com/egoriku/grodnoroads/maps/compose/core/CameraPosition.android.kt
+++ b/kmp/compose/maps-compose/src/androidMain/kotlin/com/egoriku/grodnoroads/maps/compose/core/CameraPosition.android.kt
@@ -11,11 +11,15 @@ actual class CameraPosition actual constructor(
 ) {
     actual constructor(
         target: LatLng,
-        zoom: Float
+        zoom: Float,
+        bearing: Float,
+        tilt: Float
     ) : this(
         platformCameraPosition = cameraPosition {
             target(target.platform)
             zoom(zoom)
+            bearing(bearing)
+            tilt(tilt)
         }
     )
 }

--- a/kmp/compose/maps-compose/src/commonMain/kotlin/com/egoriku/grodnoroads/maps/compose/core/CameraPosition.kt
+++ b/kmp/compose/maps-compose/src/commonMain/kotlin/com/egoriku/grodnoroads/maps/compose/core/CameraPosition.kt
@@ -8,6 +8,8 @@ expect class CameraPosition(platformCameraPosition: PlatformCameraPosition) {
 
     constructor(
         target: LatLng,
-        zoom: Float
+        zoom: Float,
+        bearing: Float = 0f,
+        tilt: Float = 0f
     )
 }

--- a/kmp/compose/maps-compose/src/commonMain/kotlin/com/egoriku/grodnoroads/maps/compose/updater/MapUpdaterBase.kt
+++ b/kmp/compose/maps-compose/src/commonMain/kotlin/com/egoriku/grodnoroads/maps/compose/updater/MapUpdaterBase.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 
-internal const val NAVIGATION_CAMERA_TILT = 55.0
+const val NAVIGATION_CAMERA_TILT = 55.0
 internal const val SHADOW_CAMERA_ANIMATION_DURATION_MS = 400
 private const val MINIMUM_DISTANCE_FOR_ANIMATION = 5
 

--- a/kmp/compose/maps-compose/src/iosMain/kotlin/com/egoriku/grodnoroads/maps/compose/core/CameraPosition.ios.kt
+++ b/kmp/compose/maps-compose/src/iosMain/kotlin/com/egoriku/grodnoroads/maps/compose/core/CameraPosition.ios.kt
@@ -13,11 +13,15 @@ actual class CameraPosition actual constructor(
 ) {
     actual constructor(
         target: LatLng,
-        zoom: Float
+        zoom: Float,
+        bearing: Float,
+        tilt: Float
     ) : this(
         platformCameraPosition = GMSCameraPosition.cameraWithTarget(
             target = target.cValue,
-            zoom = zoom
+            zoom = zoom,
+            bearing = bearing.toDouble(),
+            viewingAngle = tilt.toDouble()
         )
     )
 }

--- a/kmp/features/guidance/src/commonMain/kotlin/com/egoriku/grodnoroads/guidance/screen/GuidanceScreen.kt
+++ b/kmp/features/guidance/src/commonMain/kotlin/com/egoriku/grodnoroads/guidance/screen/GuidanceScreen.kt
@@ -15,9 +15,11 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -102,6 +104,7 @@ import com.egoriku.grodnoroads.maps.compose.core.toScreenLatLng
 import com.egoriku.grodnoroads.maps.compose.extension.projection
 import com.egoriku.grodnoroads.maps.compose.impl.onMapScope
 import com.egoriku.grodnoroads.maps.compose.updater.MapUpdater
+import com.egoriku.grodnoroads.maps.compose.updater.NAVIGATION_CAMERA_TILT
 import com.egoriku.grodnoroads.quicksettings.screen.QuickSettingsBottomSheet
 import com.egoriku.grodnoroads.shared.models.MapEventType
 import com.egoriku.grodnoroads.specialevent.screen.SpecialEventDialog
@@ -270,7 +273,7 @@ fun GuidanceScreen(
 
         var projection by rememberMutableState<Projection?> { null }
         var mapUpdater by rememberMutableState<MapUpdater?> { null }
-        var mapBearing by rememberMutableState { 0f }
+        var mapBearing by rememberSaveable { mutableFloatStateOf(0f) }
 
         LaunchedEffect(mapUpdater, appMode) {
             val mapUpdater = mapUpdater
@@ -300,7 +303,9 @@ fun GuidanceScreen(
                 cameraPositionProvider = {
                     CameraPosition(
                         target = initialLocation,
-                        zoom = mapConfig.zoomLevel
+                        zoom = mapConfig.zoomLevel,
+                        bearing = mapBearing,
+                        tilt = if (appMode == AppMode.Drive) NAVIGATION_CAMERA_TILT.toFloat() else 0f
                     )
                 },
                 onMapUpdaterChange = { mapUpdater = it },


### PR DESCRIPTION
Preserve bearing and tilt across configuration changes by:
- Adding bearing and tilt parameters to CameraPosition (common/android/ios)
- Using rememberSaveable for mapBearing to survive rotation
- Passing bearing and tilt to initial camera position provider
- Making NAVIGATION_CAMERA_TILT public for reuse in GuidanceScreen