### PR TITLE
Adjust Map overlay depending on screen size, migrate to material3 adaptive library

### DIFF
--- a/CHANGELOG_ANDROID.md
+++ b/CHANGELOG_ANDROID.md
@@ -17,6 +17,7 @@
 - Update medium speed camera color
 - Merge mobile cameras that are close to each other (within 300 m) into a single marker
 - Dynamic map zoom that adjusts to the selected city's default zoom level
+- Adjust map overlay depending on screen size
 
 ## [1.6.0] - 2026-06-27
 

--- a/CHANGELOG_IOS.md
+++ b/CHANGELOG_IOS.md
@@ -29,4 +29,5 @@
 - Update medium speed camera color
 - Merge mobile cameras that are close to each other (within 300 m) into a single marker
 - Dynamic map zoom that adjusts to the selected city's default zoom level
+- Adjust map overlay depending on screen size
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,10 @@ Example structure:
 - ...
 ```
 
+## Agent Behavior
+
+- **Do not use Agent tool or any sub-agents.** Do all work directly in the main conversation thread, one step at a time.
+
 ## Compose
 
 - Use `rememberMutableState { value }` instead of `val state by remember { mutableStateOf(value) }`

--- a/app/android/build.gradle.kts
+++ b/app/android/build.gradle.kts
@@ -95,7 +95,6 @@ dependencies {
 
     implementation(libs.compose.foundation)
     implementation(libs.compose.material3)
-    implementation(libs.compose.material3.windowsize)
 
     implementation(project.dependencies.platform(libs.firebase.bom))
     implementation(libs.firebase.analytics)

--- a/app/android/src/main/kotlin/com/egoriku/grodnoroads/MainActivity.kt
+++ b/app/android/src/main/kotlin/com/egoriku/grodnoroads/MainActivity.kt
@@ -7,8 +7,6 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
-import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -16,7 +14,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.arkivanov.decompose.defaultComponentContext
-import com.egoriku.grodnoroads.foundation.core.LocalWindowSizeClass
 import com.egoriku.grodnoroads.foundation.theme.GrodnoRoadsM3Theme
 import com.egoriku.grodnoroads.foundation.theme.LocalPlatform
 import com.egoriku.grodnoroads.foundation.theme.Platform.Android
@@ -27,7 +24,6 @@ import com.egoriku.grodnoroads.root.screen.RootContent
 // Don't use ComponentActivity, due to it breaks language change
 class MainActivity : AppCompatActivity() {
 
-    @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         val splash = installSplashScreen()
         splash.setKeepOnScreenCondition { true }
@@ -66,10 +62,7 @@ class MainActivity : AppCompatActivity() {
                 }
 
                 GrodnoRoadsM3Theme(isDarkTheme) {
-                    CompositionLocalProvider(
-                        LocalWindowSizeClass provides calculateWindowSizeClass(this),
-                        LocalPlatform provides Android
-                    ) {
+                    CompositionLocalProvider(LocalPlatform provides Android) {
                         RootContent(root)
                     }
                 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,7 @@ compose-ui-tooling = { module = "org.jetbrains.compose.ui:ui-tooling", version.r
 compose-ui-tooling-preview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "compose" }
 
 compose-material3 = "org.jetbrains.compose.material3:material3:1.9.0"
-compose-material3-windowsize = "org.jetbrains.compose.material3:material3-window-size-class:1.9.0"
+compose-material3-adaptive = "org.jetbrains.compose.material3.adaptive:adaptive:1.3.0-beta02"
 
 decompose = { module = "com.arkivanov.decompose:decompose", version.ref = "decompose" }
 decompose-compose = { module = "com.arkivanov.decompose:extensions-compose", version.ref = "decompose" }

--- a/kmp/compose/foundation/core/build.gradle.kts
+++ b/kmp/compose/foundation/core/build.gradle.kts
@@ -13,7 +13,7 @@ kotlin {
             api(libs.compose.runtime)
             implementation(libs.compose.foundation)
             implementation(libs.compose.material3)
-            implementation(libs.compose.material3.windowsize)
+            implementation(libs.compose.material3.adaptive)
         }
         androidMain.dependencies {
             implementation(libs.androidx.activity.compose)

--- a/kmp/compose/foundation/core/src/commonMain/kotlin/com.egoriku.grodnoroads.foundation.core/LocalComposition.kt
+++ b/kmp/compose/foundation/core/src/commonMain/kotlin/com.egoriku.grodnoroads.foundation.core/LocalComposition.kt
@@ -1,6 +1,0 @@
-package com.egoriku.grodnoroads.foundation.core
-
-import androidx.compose.material3.windowsizeclass.WindowSizeClass
-import androidx.compose.runtime.compositionLocalOf
-
-val LocalWindowSizeClass = compositionLocalOf<WindowSizeClass> { error("SizeClass not present") }

--- a/kmp/compose/foundation/core/src/commonMain/kotlin/com.egoriku.grodnoroads.foundation.core/WindowSizeClass.kt
+++ b/kmp/compose/foundation/core/src/commonMain/kotlin/com.egoriku.grodnoroads.foundation.core/WindowSizeClass.kt
@@ -1,14 +1,6 @@
 package com.egoriku.grodnoroads.foundation.core
 
-import androidx.compose.material3.adaptive.currentWindowAdaptiveInfoV2
-import androidx.compose.runtime.Composable
 import androidx.window.core.layout.WindowSizeClass as WindowCoreSizeClass
-
-@Composable
-fun isMediumScreenWidth(): Boolean {
-    val windowAdaptiveInfo = currentWindowAdaptiveInfoV2()
-    return windowAdaptiveInfo.windowSizeClass.isMediumScreenWidth()
-}
 
 fun WindowCoreSizeClass.isMediumScreenWidth(): Boolean {
     return isWidthAtLeastBreakpoint(WindowCoreSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND)

--- a/kmp/compose/foundation/core/src/commonMain/kotlin/com.egoriku.grodnoroads.foundation.core/WindowSizeClass.kt
+++ b/kmp/compose/foundation/core/src/commonMain/kotlin/com.egoriku.grodnoroads.foundation.core/WindowSizeClass.kt
@@ -1,0 +1,19 @@
+package com.egoriku.grodnoroads.foundation.core
+
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfoV2
+import androidx.compose.runtime.Composable
+import androidx.window.core.layout.WindowSizeClass as WindowCoreSizeClass
+
+@Composable
+fun isMediumScreenWidth(): Boolean {
+    val windowAdaptiveInfo = currentWindowAdaptiveInfoV2()
+    return windowAdaptiveInfo.windowSizeClass.isMediumScreenWidth()
+}
+
+fun WindowCoreSizeClass.isMediumScreenWidth(): Boolean {
+    return isWidthAtLeastBreakpoint(WindowCoreSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND)
+}
+
+fun WindowCoreSizeClass.isExpandedScreenWidth(): Boolean {
+    return isWidthAtLeastBreakpoint(WindowCoreSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND)
+}

--- a/kmp/features/guidance/build.gradle.kts
+++ b/kmp/features/guidance/build.gradle.kts
@@ -40,6 +40,7 @@ kotlin {
             implementation(projects.kmp.libraries.location)
             implementation(projects.kmp.libraries.logger)
 
+            implementation(libs.compose.material3.adaptive)
             implementation(libs.decompose)
             implementation(libs.dev.gitlive.firebase.database)
             implementation(libs.essenty.lifecycle.coroutines)

--- a/kmp/features/guidance/src/commonMain/kotlin/com/egoriku/grodnoroads/guidance/screen/ui/mode/DefaultOverlay.kt
+++ b/kmp/features/guidance/src/commonMain/kotlin/com/egoriku/grodnoroads/guidance/screen/ui/mode/DefaultOverlay.kt
@@ -17,12 +17,15 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfoV2
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -34,15 +37,18 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.egoriku.grodnoroads.extensions.Uuid
 import com.egoriku.grodnoroads.foundation.core.animation.FadeInOutAnimatedVisibility
+import com.egoriku.grodnoroads.foundation.core.isMediumScreenWidth
 import com.egoriku.grodnoroads.foundation.core.rememberMutableState
 import com.egoriku.grodnoroads.foundation.icons.GrodnoRoads
 import com.egoriku.grodnoroads.foundation.icons.outlined.More
 import com.egoriku.grodnoroads.foundation.preview.GrodnoRoadsM3ThemePreview
 import com.egoriku.grodnoroads.foundation.preview.PreviewGrodnoRoadsDarkLight
+import com.egoriku.grodnoroads.foundation.uikit.VerticalSpacer
 import com.egoriku.grodnoroads.foundation.uikit.button.PrimaryInverseCircleButton
 import com.egoriku.grodnoroads.foundation.uikit.button.common.Size
 import com.egoriku.grodnoroads.guidance.domain.model.Alert
@@ -64,37 +70,39 @@ fun DefaultOverlay(
     modifier: Modifier = Modifier,
     onOpenQuickSettings: () -> Unit
 ) {
-    Box(modifier = modifier.padding(top = 8.dp)) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(contentPadding),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            if (isDriveMode) {
-                Row(
-                    modifier = Modifier
-                        .padding(start = 16.dp)
-                        .fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy((-8).dp)
-                ) {
-                    CarSpeed(speed = currentSpeed)
-                    if (speedLimit != -1) {
-                        SpeedLimit(limit = speedLimit)
-                    }
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(top = 8.dp, start = 16.dp, end = 16.dp)
+    ) {
+        if (isDriveMode) {
+            when {
+                currentWindowAdaptiveInfoV2().windowSizeClass.isMediumScreenWidth() -> {
+                    TabletOverlay(
+                        contentPadding = contentPadding,
+                        currentSpeed = currentSpeed,
+                        speedLimit = speedLimit,
+                        alerts = alerts
+                    )
                 }
-                Alerts(alerts = alerts)
+                else -> {
+                    PhoneOverlay(
+                        contentPadding = contentPadding,
+                        currentSpeed = currentSpeed,
+                        speedLimit = speedLimit,
+                        alerts = alerts
+                    )
+                }
             }
         }
         FadeInOutAnimatedVisibility(
             visible = isOverlayVisible,
-            modifier = Modifier.align(Alignment.TopEnd)
+            modifier = Modifier
+                .padding(top = 8.dp)
+                .padding(contentPadding)
+                .align(Alignment.TopEnd)
         ) {
             PrimaryInverseCircleButton(
-                modifier = Modifier
-                    .padding(contentPadding)
-                    .padding(horizontal = 16.dp),
                 onClick = onOpenQuickSettings,
                 size = Size.Small
             ) {
@@ -103,6 +111,68 @@ fun DefaultOverlay(
                     contentDescription = null
                 )
             }
+        }
+    }
+}
+
+@Composable
+private fun PhoneOverlay(
+    contentPadding: PaddingValues,
+    currentSpeed: Int,
+    speedLimit: Int,
+    alerts: List<Alert>
+) {
+    Column(
+        modifier = Modifier.padding(contentPadding),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        SpeedRow(
+            currentSpeed = currentSpeed,
+            speedLimit = speedLimit
+        )
+        Alerts(alerts = alerts)
+    }
+}
+
+@Composable
+private fun TabletOverlay(
+    contentPadding: PaddingValues,
+    currentSpeed: Int,
+    speedLimit: Int,
+    alerts: List<Alert>
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(contentPadding)
+    ) {
+        SpeedRow(
+            currentSpeed = currentSpeed,
+            speedLimit = speedLimit
+        )
+        Alerts(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .widthIn(max = 500.dp),
+            alerts = alerts
+        )
+    }
+}
+
+@Composable
+private fun SpeedRow(
+    currentSpeed: Int,
+    speedLimit: Int,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy((-8).dp)
+    ) {
+        CarSpeed(speed = currentSpeed)
+        if (speedLimit != -1) {
+            SpeedLimit(limit = speedLimit)
         }
     }
 }
@@ -183,16 +253,19 @@ private fun SpeedLimit(limit: Int) {
     }
 }
 
+@Preview(widthDp = 1000, heightDp = 400)
 @PreviewGrodnoRoadsDarkLight
 @Composable
 private fun DefaultOverlayPreview() = GrodnoRoadsM3ThemePreview {
     var limit by rememberMutableState { -1 }
+    var driveMode by rememberMutableState { true }
 
-    Box {
+    Column {
         DefaultOverlay(
+            modifier = Modifier.weight(1f),
             contentPadding = PaddingValues(),
             isOverlayVisible = true,
-            isDriveMode = true,
+            isDriveMode = driveMode,
             currentSpeed = 120,
             speedLimit = limit,
             alerts = listOf(
@@ -221,18 +294,24 @@ private fun DefaultOverlayPreview() = GrodnoRoadsM3ThemePreview {
             ),
             onOpenQuickSettings = {}
         )
+        HorizontalDivider()
+        VerticalSpacer(8.dp)
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .align(Alignment.BottomCenter),
-            horizontalArrangement = Arrangement.Center
+                .align(Alignment.CenterHorizontally),
+            horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally)
         ) {
             Button(onClick = { limit = 50 }) {
-                Text(text = "Set limit")
+                Text(text = "Speed limit")
             }
             Button(onClick = { limit = -1 }) {
-                Text(text = "Reset limit")
+                Text(text = "Reset")
+            }
+            Button(onClick = { driveMode = !driveMode }) {
+                Text(text = "Toggle Mode")
             }
         }
+        VerticalSpacer(8.dp)
     }
 }

--- a/kmp/features/guidance/src/commonMain/kotlin/com/egoriku/grodnoroads/guidance/screen/ui/mode/drive/alerts/Alerts.kt
+++ b/kmp/features/guidance/src/commonMain/kotlin/com/egoriku/grodnoroads/guidance/screen/ui/mode/drive/alerts/Alerts.kt
@@ -50,7 +50,7 @@ fun Alerts(
     LazyColumn(
         modifier = modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(16.dp),
-        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 4.dp)
+        contentPadding = PaddingValues(vertical = 4.dp)
     ) {
         items(items = alerts, key = { it.id }) { alert ->
             when (alert) {

--- a/kmp/features/root/src/iosMain/kotlin/com/egoriku/grodnoroads/root/screen/RootViewController.kt
+++ b/kmp/features/root/src/iosMain/kotlin/com/egoriku/grodnoroads/root/screen/RootViewController.kt
@@ -2,8 +2,6 @@ package com.egoriku.grodnoroads.root.screen
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
-import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ExperimentalComposeApi
 import androidx.compose.runtime.collectAsState
@@ -13,7 +11,6 @@ import androidx.compose.ui.window.ComposeUIViewController
 import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.extensions.compose.stack.animation.predictiveback.PredictiveBackGestureOverlay
 import com.arkivanov.essenty.backhandler.BackDispatcher
-import com.egoriku.grodnoroads.foundation.core.LocalWindowSizeClass
 import com.egoriku.grodnoroads.foundation.theme.GrodnoRoadsM3Theme
 import com.egoriku.grodnoroads.foundation.theme.LocalPlatform
 import com.egoriku.grodnoroads.foundation.theme.Platform.IOS
@@ -24,7 +21,6 @@ import com.egoriku.grodnoroads.root.domain.RootComponent
 object RootViewController {
 
     @OptIn(
-        ExperimentalMaterial3WindowSizeClassApi::class,
         ExperimentalComposeApi::class,
         ExperimentalDecomposeApi::class
     )
@@ -47,10 +43,7 @@ object RootViewController {
                 backIcon = null
             ) {
                 GrodnoRoadsM3Theme(isDarkTheme) {
-                    CompositionLocalProvider(
-                        LocalWindowSizeClass provides calculateWindowSizeClass(),
-                        LocalPlatform provides IOS
-                    ) {
+                    CompositionLocalProvider(LocalPlatform provides IOS) {
                         RootContent(rootComponent)
                     }
                 }

--- a/kmp/features/tabs/build.gradle.kts
+++ b/kmp/features/tabs/build.gradle.kts
@@ -20,7 +20,7 @@ kotlin {
             implementation(projects.kmp.shared.models)
             implementation(projects.kmp.libraries.extensions)
 
-            implementation(libs.compose.material3.windowsize)
+            implementation(libs.compose.material3.adaptive)
             implementation(libs.decompose.compose)
             implementation(libs.decompose)
         }

--- a/kmp/features/tabs/src/commonMain/kotlin/com/egoriku/grodnoroads/mainflow/screen/TabsScreen.kt
+++ b/kmp/features/tabs/src/commonMain/kotlin/com/egoriku/grodnoroads/mainflow/screen/TabsScreen.kt
@@ -6,11 +6,12 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.add
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
-import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfoV2
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -25,9 +26,9 @@ import com.arkivanov.decompose.router.stack.ChildStack
 import com.egoriku.grodnoroads.appsettings.screen.AppSettingsScreen
 import com.egoriku.grodnoroads.eventreporting.screen.EventReportingScreen
 import com.egoriku.grodnoroads.extensions.decompose.onChild
-import com.egoriku.grodnoroads.foundation.core.LocalWindowSizeClass
 import com.egoriku.grodnoroads.foundation.core.animation.HorizontalSlideAnimatedVisibility
 import com.egoriku.grodnoroads.foundation.core.animation.VerticalSlideAnimatedVisibility
+import com.egoriku.grodnoroads.foundation.core.isExpandedScreenWidth
 import com.egoriku.grodnoroads.foundation.core.rememberMutableState
 import com.egoriku.grodnoroads.foundation.uikit.NavigationBar
 import com.egoriku.grodnoroads.foundation.uikit.NavigationBarItem
@@ -46,13 +47,11 @@ fun TabsScreen(
     tabsComponent: TabsComponent,
     modifier: Modifier = Modifier
 ) {
-    val windowSizeClass = LocalWindowSizeClass.current
-
     val childStack by tabsComponent.childStack.collectAsState()
 
     Box(modifier = modifier) {
-        when (windowSizeClass.widthSizeClass) {
-            WindowWidthSizeClass.Expanded -> {
+        when {
+            currentWindowAdaptiveInfoV2().windowSizeClass.isExpandedScreenWidth() -> {
                 HorizontalOrientationLayout(
                     childStack = { childStack },
                     onSelectTab = tabsComponent::onSelectTab,

--- a/kmp/features/tabs/src/commonMain/kotlin/com/egoriku/grodnoroads/mainflow/screen/TabsScreen.kt
+++ b/kmp/features/tabs/src/commonMain/kotlin/com/egoriku/grodnoroads/mainflow/screen/TabsScreen.kt
@@ -158,7 +158,7 @@ private fun HorizontalOrientationLayout(
         label = "leftPadding"
     )
 
-    val contentPadding = WindowInsets.systemBars
+    val contentPadding = WindowInsets.safeDrawing
         .add(WindowInsets(left = leftPadding))
         .asPaddingValues()
 


### PR DESCRIPTION
Before:
<img width="1000"  alt="Screenshot_20260713_195440" src="https://github.com/user-attachments/assets/1938361a-f716-4f4e-b381-831fd89813a1" />
After:
<img width="1000"  alt="Screenshot_20260713_200145" src="https://github.com/user-attachments/assets/006a9450-bb49-4609-b08b-4f076914845c" />
