### PR TITLE
Refactor LocationService to use callbackFlow instead of StateFlow

### DIFF
--- a/kmp/features/guidance/src/commonMain/kotlin/com/egoriku/grodnoroads/guidance/domain/store/location/LocationStoreFactory.kt
+++ b/kmp/features/guidance/src/commonMain/kotlin/com/egoriku/grodnoroads/guidance/domain/store/location/LocationStoreFactory.kt
@@ -42,23 +42,24 @@ internal class LocationStoreFactory(
 
                 onAction<Unit> {
                     launch {
-                        locationService.getLastKnownLocation()?.run {
-                            dispatch(Message.OnInitialLocation(latLng))
+                        val lastLocation = locationService.getLastKnownLocation()
+
+                        if (lastLocation != null) {
+                            dispatch(Message.OnInitialLocation(lastLocation.latLng))
+                        } else {
+                            dataStore.data
+                                .map { it.defaultCity }
+                                .distinctUntilChanged()
+                                .onEach { dispatch(Message.OnInitialLocation(it.latLng)) }
+                                .launchIn(this)
                         }
                     }
-                    dataStore.data
-                        .map { it.defaultCity }
-                        .distinctUntilChanged()
-                        .onEach { dispatch(Message.OnInitialLocation(it.latLng)) }
-                        .launchIn(this)
                 }
                 onIntent<StartLocationUpdates> {
-                    locationService.startLocationUpdates()
-
                     dispatch(Message.OnNewLocation(LastLocation.None))
 
                     locationJob = launch {
-                        locationService.lastLocationFlow
+                        locationService.locationUpdates()
                             .filterNotNull()
                             .map { LastLocation(it.latLng, it.bearing, it.speed) }
                             .collect {
@@ -70,7 +71,8 @@ internal class LocationStoreFactory(
                     }
                 }
                 onIntent<StopLocationUpdates> {
-                    locationService.stopLocationUpdates()
+                    locationJob?.cancel()
+                    locationJob = null
                 }
                 onIntent<RequestCurrentLocation> {
                     launch {

--- a/kmp/shared/geolocation/src/androidMain/kotlin/com/egoriku/grodnoroads/shared.geolocation/AndroidLocationService.kt
+++ b/kmp/shared/geolocation/src/androidMain/kotlin/com/egoriku/grodnoroads/shared.geolocation/AndroidLocationService.kt
@@ -14,8 +14,10 @@ import com.google.android.gms.location.LocationResult
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.Priority
 import com.google.android.gms.tasks.CancellationTokenSource
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.tasks.await
 
 class AndroidLocationService(context: Context) : LocationService {
@@ -23,65 +25,52 @@ class AndroidLocationService(context: Context) : LocationService {
 
     private var lastKnownLocation: LocationInfo? = null
 
-    override val lastLocationFlow = MutableStateFlow<LocationInfo?>(null)
-
-    private val locationCallback = object : LocationCallback() {
-
-        override fun onLocationResult(locationResult: LocationResult) {
-            val location = locationResult.lastLocation ?: return
-
-            lastLocationFlow.tryEmit(
-                LocationInfo(
-                    latLng = LatLng(location.latitude, location.longitude),
-                    bearing = location.bearing,
-                    speed = when {
-                        location.hasSpeed() -> location.speed.toKilometersPerHour()
-                        else -> 0
-                    }
-                )
-            )
-        }
-    }
-
+    // Note: each collector creates a separate LocationCallback — prefer single collector
     @SuppressLint("MissingPermission")
-    override fun startLocationUpdates() {
-        fusedLocationProvider.removeLocationUpdates(locationCallback)
+    override fun locationUpdates(): Flow<LocationInfo?> = callbackFlow {
+        val callback = object : LocationCallback() {
+            override fun onLocationResult(result: LocationResult) {
+                val location = result.lastLocation ?: return
+                trySend(location.toLocationInfo())
+            }
+        }
+
         fusedLocationProvider.requestLocationUpdates(
             highPrecisionLowIntervalRequest,
-            locationCallback,
+            callback,
             Looper.getMainLooper()
         )
-    }
 
-    override fun stopLocationUpdates() {
-        fusedLocationProvider.removeLocationUpdates(locationCallback)
+        awaitClose {
+            fusedLocationProvider.removeLocationUpdates(callback)
+        }
     }
 
     override suspend fun getLastKnownLocation(): LocationInfo? {
         if (lastKnownLocation == null) {
-            lastKnownLocation = requestLocation().toLocationInfo()
+            lastKnownLocation = requestCurrentLocation()
         }
 
         return lastKnownLocation
     }
 
-    override suspend fun requestCurrentLocation(): LocationInfo? {
-        return requestLocation().toLocationInfo()
-    }
-
-    @OptIn(ExperimentalCoroutinesApi::class)
     @SuppressLint("MissingPermission")
-    private suspend fun requestLocation(): Location? {
+    override suspend fun requestCurrentLocation(): LocationInfo? {
         val cancellationTokenSource = CancellationTokenSource()
 
-        return runCatching {
+        return try {
             fusedLocationProvider.getCurrentLocation(
                 QUALITY_HIGH_ACCURACY,
                 cancellationTokenSource.token
-            ).await(cancellationTokenSource)
-        }.onFailure {
-            logD(it.message.toString())
-        }.getOrNull()
+            ).await(cancellationTokenSource).toLocationInfo()
+        } catch (c: CancellationException) {
+            throw c
+        } catch (e: Exception) {
+            logD(e.message.toString())
+            null
+        } finally {
+            cancellationTokenSource.cancel()
+        }
     }
 
     companion object {
@@ -98,7 +87,10 @@ class AndroidLocationService(context: Context) : LocationService {
                 location != null -> LocationInfo(
                     latLng = LatLng(location.latitude, location.longitude),
                     bearing = location.bearing,
-                    speed = 0
+                    speed = when {
+                        location.hasSpeed() -> location.speed.toKilometersPerHour()
+                        else -> 0
+                    }
                 )
                 else -> null
             }

--- a/kmp/shared/geolocation/src/commonMain/kotlin/com/egoriku/grodnoroads/shared.geolocation/LocationService.kt
+++ b/kmp/shared/geolocation/src/commonMain/kotlin/com/egoriku/grodnoroads/shared.geolocation/LocationService.kt
@@ -1,15 +1,12 @@
 package com.egoriku.grodnoroads.shared.geolocation
 
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.Flow
 
 interface LocationService {
 
-    val lastLocationFlow: StateFlow<LocationInfo?>
+    fun locationUpdates(): Flow<LocationInfo?>
 
     suspend fun getLastKnownLocation(): LocationInfo?
 
     suspend fun requestCurrentLocation(): LocationInfo?
-
-    fun startLocationUpdates()
-    fun stopLocationUpdates()
 }

--- a/kmp/shared/geolocation/src/iosMain/kotlin/com/egoriku/grodnoroads/shared.geolocation/IosLocationService.kt
+++ b/kmp/shared/geolocation/src/iosMain/kotlin/com/egoriku/grodnoroads/shared.geolocation/IosLocationService.kt
@@ -2,29 +2,35 @@ package com.egoriku.grodnoroads.shared.geolocation
 
 import com.egoriku.grodnoroads.logger.logD
 import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import platform.CoreLocation.CLLocation
+import platform.Foundation.NSError
 
 class IosLocationService : LocationService {
 
     private val locationDelegate = LocationDelegate()
     private var lastKnownLocation: LocationInfo? = null
+    private val requestMutex = Mutex()
 
-    init {
+    // Note: must be collected from a single collector — LocationDelegate has a single listener slot
+    override fun locationUpdates(): Flow<LocationInfo?> = callbackFlow {
+        locationDelegate.startUpdatingLocation()
         locationDelegate.monitorLocation { location ->
-            lastLocationFlow.tryEmit(location.toLocationInfo())
+            trySend(location.toLocationInfo())
+        }
+        awaitClose {
+            locationDelegate.stopTracking()
         }
     }
 
-    override val lastLocationFlow = MutableStateFlow<LocationInfo?>(null)
-
-    override fun startLocationUpdates() = locationDelegate.startUpdatingLocation()
-
-    override fun stopLocationUpdates() = locationDelegate.stopTracking()
-
     override suspend fun getLastKnownLocation(): LocationInfo? {
         if (lastKnownLocation == null) {
-            lastKnownLocation = requestLocation()
+            lastKnownLocation = requestCurrentLocation()
         }
 
         return lastKnownLocation
@@ -32,16 +38,24 @@ class IosLocationService : LocationService {
 
     override suspend fun requestCurrentLocation(): LocationInfo? = requestLocation()
 
-    private suspend fun requestLocation(): LocationInfo? {
-        return suspendCoroutine { continuation ->
-            locationDelegate.requestLocation { error, location ->
-                if (location != null) {
-                    continuation.resume(location.toLocationInfo())
-                } else {
-                    logD("requestLocation error=${error?.localizedDescription}")
-                    continuation.resume(null)
+    private suspend fun requestLocation(): LocationInfo? = requestMutex.withLock {
+        return suspendCancellableCoroutine { continuation ->
+            val callback = { error: NSError?, location: CLLocation? ->
+                if (continuation.isActive) {
+                    if (location != null) {
+                        continuation.resume(location.toLocationInfo())
+                    } else {
+                        logD("requestLocation error=${error?.localizedDescription}")
+                        continuation.resume(null)
+                    }
                 }
             }
+
+            continuation.invokeOnCancellation {
+                locationDelegate.cancelRequest()
+            }
+
+            locationDelegate.requestLocation(callback)
         }
     }
 }

--- a/kmp/shared/geolocation/src/iosMain/kotlin/com/egoriku/grodnoroads/shared.geolocation/LocationDelegate.kt
+++ b/kmp/shared/geolocation/src/iosMain/kotlin/com/egoriku/grodnoroads/shared.geolocation/LocationDelegate.kt
@@ -31,6 +31,10 @@ internal class LocationDelegate :
         manager.requestLocation()
     }
 
+    fun cancelRequest() {
+        oneTimeLocationCallback = null
+    }
+
     fun startUpdatingLocation() {
         if (isTracking) return
 


### PR DESCRIPTION
- Replace StateFlow with Flow-based API for location updates
- Remove startLocationUpdates/stopLocationUpdates in favor of Flow lifecycle
- Simplify LocationStoreFactory to collect from Flow directly
- Improve error handling in requestCurrentLocation with proper CancellationException handling