### PR TITLE
Replace runCatching with runCatchingCancellable to preserve CancellationException

### DIFF
--- a/kmp/compose/location-requester/build.gradle.kts
+++ b/kmp/compose/location-requester/build.gradle.kts
@@ -11,6 +11,7 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation(projects.kmp.compose.foundation.core)
+            implementation(projects.kmp.libraries.extensions)
 
             implementation(libs.compose.material3)
             implementation(libs.compose.runtime)

--- a/kmp/compose/location-requester/src/androidMain/kotlin/com/egoriku/grodnoroads/location/requester/internal/SettingsRequest.kt
+++ b/kmp/compose/location-requester/src/androidMain/kotlin/com/egoriku/grodnoroads/location/requester/internal/SettingsRequest.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
+import com.egoriku.grodnoroads.extensions.coroutines.runCatchingCancellable
 import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.common.api.ResolvableApiException
 import com.google.android.gms.location.LocationRequest
@@ -42,13 +43,13 @@ internal fun rememberLocationSettingsRequest() = remember {
 
 internal suspend fun SettingsClient.invalidateLocationSettings(
     request: LocationSettingsRequest
-) = runCatching {
+) = runCatchingCancellable {
     checkLocationSettings(request).await()
     SettingsState.Resolved
 }.getOrElse { throwable ->
     when (throwable) {
         is ApiException -> {
-            runCatching {
+            runCatchingCancellable {
                 SettingsState.Resolvable(throwable as ResolvableApiException)
             }.getOrDefault(SettingsState.Unresolvable)
         }

--- a/kmp/features/eventReporting/src/commonMain/kotlin/com/egoriku/grodnoroads/eventreporting/data/repository/ReportingRepositoryImpl.kt
+++ b/kmp/features/eventReporting/src/commonMain/kotlin/com/egoriku/grodnoroads/eventreporting/data/repository/ReportingRepositoryImpl.kt
@@ -5,6 +5,7 @@ import androidx.datastore.preferences.core.Preferences
 import com.egoriku.grodnoroads.datastore.edit
 import com.egoriku.grodnoroads.eventreporting.domain.repository.ReportingRepository
 import com.egoriku.grodnoroads.extensions.common.ResultOf
+import com.egoriku.grodnoroads.extensions.coroutines.runCatchingCancellable
 import com.egoriku.grodnoroads.shared.models.dto.MobileCameraDTO
 import com.egoriku.grodnoroads.shared.models.dto.ReportsDTO
 import com.egoriku.grodnoroads.shared.persistent.reporting.lastReportTime
@@ -36,7 +37,7 @@ internal class ReportingRepositoryImpl(
     }
 
     private suspend fun <T> reportData(path: String, data: T): ResultOf<Unit> {
-        return runCatching {
+        return runCatchingCancellable {
             checkAndUpdateRateLimit()
             databaseReference
                 .child(path)

--- a/kmp/features/settings/changelog/src/commonMain/kotlin/com/egoriku/grodnoroads/settings/changelog/data/repository/ChangelogRepositoryImpl.kt
+++ b/kmp/features/settings/changelog/src/commonMain/kotlin/com/egoriku/grodnoroads/settings/changelog/data/repository/ChangelogRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.egoriku.grodnoroads.settings.changelog.data.repository
 
 import com.egoriku.grodnoroads.extensions.common.ResultOf
+import com.egoriku.grodnoroads.extensions.coroutines.runCatchingCancellable
 import com.egoriku.grodnoroads.settings.changelog.data.dto.ChangelogDTO
 import com.egoriku.grodnoroads.settings.changelog.domain.model.ReleaseNotes
 import com.egoriku.grodnoroads.settings.changelog.domain.repository.ChangelogRepository
@@ -17,7 +18,7 @@ internal class ChangelogRepositoryImpl(
 ) : ChangelogRepository {
 
     override suspend fun load() = withContext(Dispatchers.IO) {
-        runCatching {
+        runCatchingCancellable {
             val changelog = firestore
                 .collection("whats_new")
                 .orderBy("code", Direction.DESCENDING)

--- a/kmp/features/settings/faq/src/commonMain/kotlin/com/egoriku/grodnoroads/settings/faq/data/repository/FaqRepositoryImpl.kt
+++ b/kmp/features/settings/faq/src/commonMain/kotlin/com/egoriku/grodnoroads/settings/faq/data/repository/FaqRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.egoriku.grodnoroads.settings.faq.data.repository
 
 import com.egoriku.grodnoroads.extensions.common.ResultOf
+import com.egoriku.grodnoroads.extensions.coroutines.runCatchingCancellable
 import com.egoriku.grodnoroads.settings.faq.data.dto.FaqDTO
 import com.egoriku.grodnoroads.settings.faq.domain.model.FAQ
 import com.egoriku.grodnoroads.settings.faq.domain.repository.FaqRepository
@@ -14,7 +15,7 @@ internal class FaqRepositoryImpl(
 ) : FaqRepository {
 
     override suspend fun load() = withContext(Dispatchers.IO) {
-        runCatching {
+        runCatchingCancellable {
             val faq = firestore
                 .collection("faq")
                 .orderBy("id")

--- a/kmp/libraries/extensions/src/commonMain/kotlin/com/egoriku/grodnoroads/extensions/coroutines/RunCatching.kt
+++ b/kmp/libraries/extensions/src/commonMain/kotlin/com/egoriku/grodnoroads/extensions/coroutines/RunCatching.kt
@@ -1,0 +1,13 @@
+package com.egoriku.grodnoroads.extensions.coroutines
+
+import kotlin.coroutines.cancellation.CancellationException
+
+inline fun <R> runCatchingCancellable(block: () -> R): Result<R> {
+    return try {
+        Result.success(block())
+    } catch (c: CancellationException) {
+        throw c
+    } catch (e: Throwable) {
+        Result.failure(e)
+    }
+}


### PR DESCRIPTION
Standard runCatching catches CancellationException which breaks structured concurrency. 
Added runCatchingCancellable to kmp/libraries/extensions and replaced all 6 usages across 5 files.