### PR TITLE
Fix duplicate voice notifications for camera alerts

### DIFF
--- a/CHANGELOG_ANDROID.md
+++ b/CHANGELOG_ANDROID.md
@@ -10,6 +10,7 @@
 
 - Fix crash when in-app update is triggered while another update is already in progress
 - Fix zoom to current location button not accounting for bearing in Default mode
+- Fix duplicate voice notifications for camera alerts
 
 ### Changed
 

--- a/CHANGELOG_IOS.md
+++ b/CHANGELOG_IOS.md
@@ -17,6 +17,7 @@
 - Fix list not scrolling to selected city when it is off-screen
 - Fix map briefly rotating to north and resetting tilt when rotating screen during navigation
 - Fix zoom to current location button not accounting for bearing in Default mode
+- Fix duplicate voice notifications for camera alerts
 
 ### Changed
 

--- a/kmp/features/guidance/src/commonMain/kotlin/com/egoriku/grodnoroads/guidance/screen/sound/PlayedAlertTracker.kt
+++ b/kmp/features/guidance/src/commonMain/kotlin/com/egoriku/grodnoroads/guidance/screen/sound/PlayedAlertTracker.kt
@@ -1,0 +1,34 @@
+package com.egoriku.grodnoroads.guidance.screen.sound
+
+import com.egoriku.grodnoroads.extensions.DateTime
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+class PlayedAlertTracker(
+    private val timeProvider: () -> Long = { DateTime.currentTimeMillis() }
+) {
+    private val history = mutableMapOf<String, Long>()
+
+    fun shouldPlay(id: String, expiration: Long = FIVE_MINUTES): Boolean {
+        val currentTime = timeProvider()
+        val lastPlayed = history[id] ?: return true
+        return currentTime - lastPlayed > expiration
+    }
+
+    fun record(id: String) {
+        history[id] = timeProvider()
+    }
+
+    fun cleanup() {
+        val currentTime = timeProvider()
+        history.entries.removeAll { currentTime - it.value > THIRTY_MINUTES }
+    }
+
+    internal fun size() = history.size
+
+    companion object {
+        val FIVE_SECONDS = 5.seconds.inWholeMilliseconds
+        val FIVE_MINUTES = 5.minutes.inWholeMilliseconds
+        val THIRTY_MINUTES = 30.minutes.inWholeMilliseconds
+    }
+}

--- a/kmp/features/guidance/src/commonMain/kotlin/com/egoriku/grodnoroads/guidance/screen/sound/SoundController.kt
+++ b/kmp/features/guidance/src/commonMain/kotlin/com/egoriku/grodnoroads/guidance/screen/sound/SoundController.kt
@@ -20,6 +20,7 @@ interface SoundController {
 
 abstract class SharedSoundController : SoundController {
     private val soundHistory = mutableMapOf<String, SoundTimeStamp>()
+    private val playedAlertIds = mutableMapOf<String, Long>()
     private val overSpeedId = Uuid.random()
 
     private val currentTimeMillis: Long
@@ -43,15 +44,14 @@ abstract class SharedSoundController : SoundController {
             MapEventType.Unsupported -> null
         } ?: return
 
-        val isSkipByDuplicate = checkDuplicate(incidentSound)
+        if (!isAlertAlreadyPlayed(id)) return
 
-        when {
-            isSkipByDuplicate -> return
-            else -> playSound(sound = incidentSound, id = id)
-        }
+        playSound(sound = incidentSound, id = id)
     }
 
     override fun playCameraLimit(id: String, speedLimit: Int, cameraType: CameraType) {
+        if (!isAlertAlreadyPlayed(id)) return
+
         val speedLimitSound = when (speedLimit) {
             40 -> Sound.SpeedLimit40
             50 -> Sound.SpeedLimit50
@@ -70,14 +70,8 @@ abstract class SharedSoundController : SoundController {
             CameraType.MediumSpeedCamera -> Sound.MediumSpeedCamera
         }
 
-        val isSkipByDuplicate = checkDuplicate(cameraSound)
-        when {
-            isSkipByDuplicate -> return
-            else -> {
-                playSound(sound = cameraSound, id = id)
-                speedLimitSound?.run { playSound(sound = this, id = "camera_$id") }
-            }
-        }
+        playSound(sound = cameraSound, id = id)
+        speedLimitSound?.run { playSound(sound = this, id = "camera_$id") }
     }
 
     private fun playSound(
@@ -99,23 +93,30 @@ abstract class SharedSoundController : SoundController {
         invalidateOldSounds()
     }
 
-    private fun checkDuplicate(sound: Sound, expiration: Long = ONE_MINUTE): Boolean {
+    private fun isAlertAlreadyPlayed(alertId: String): Boolean {
         val currentTimeMillis = currentTimeMillis
-        return soundHistory
-            .filterValues { soundTimeStamp ->
-                soundTimeStamp.sound == sound &&
-                    soundTimeStamp.timestamp >= currentTimeMillis - expiration
-            }
-            .isNotEmpty()
+        val lastPlayed = playedAlertIds[alertId]
+        if (lastPlayed != null && currentTimeMillis - lastPlayed < FIVE_MINUTE) {
+            return false
+        }
+        playedAlertIds[alertId] = currentTimeMillis
+        invalidateOldSounds()
+        return true
     }
 
     private fun invalidateOldSounds() {
         val currentTime = currentTimeMillis
-        val invalidIds = soundHistory
+        val invalidSoundIds = soundHistory
             .filterValues { currentTime - it.timestamp > THIRTY_MINUTES }
             .keys
 
-        invalidIds.forEach(soundHistory::remove)
+        invalidSoundIds.forEach(soundHistory::remove)
+
+        val invalidAlertIds = playedAlertIds
+            .filterValues { currentTime - it > THIRTY_MINUTES }
+            .keys
+
+        invalidAlertIds.forEach(playedAlertIds::remove)
     }
 
     private data class SoundTimeStamp(
@@ -125,7 +126,6 @@ abstract class SharedSoundController : SoundController {
 
     companion object {
         val FIVE_SECONDS = 5.seconds.inWholeMilliseconds
-        val ONE_MINUTE = 30.seconds.inWholeMilliseconds
         val FIVE_MINUTE = 5.minutes.inWholeMilliseconds
         val THIRTY_MINUTES = 30.minutes.inWholeMilliseconds
     }

--- a/kmp/features/guidance/src/commonMain/kotlin/com/egoriku/grodnoroads/guidance/screen/sound/SoundController.kt
+++ b/kmp/features/guidance/src/commonMain/kotlin/com/egoriku/grodnoroads/guidance/screen/sound/SoundController.kt
@@ -1,12 +1,9 @@
 package com.egoriku.grodnoroads.guidance.screen.sound
 
-import com.egoriku.grodnoroads.extensions.DateTime
 import com.egoriku.grodnoroads.extensions.Uuid
 import com.egoriku.grodnoroads.guidance.domain.model.CameraType
 import com.egoriku.grodnoroads.shared.audioplayer.Sound
 import com.egoriku.grodnoroads.shared.models.MapEventType
-import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Duration.Companion.seconds
 
 interface SoundController {
 
@@ -18,20 +15,20 @@ interface SoundController {
     fun setLoudness(loudness: Int)
 }
 
-abstract class SharedSoundController : SoundController {
-    private val soundHistory = mutableMapOf<String, SoundTimeStamp>()
+abstract class SharedSoundController(
+    private val tracker: PlayedAlertTracker = PlayedAlertTracker()
+) : SoundController {
     private val overSpeedId = Uuid.random()
-
-    private val currentTimeMillis: Long
-        get() = DateTime.currentTimeMillis()
 
     abstract fun enqueueSound(sound: Sound)
 
-    override fun playOverSpeed() = playSound(
-        sound = Sound.OverSpeed,
-        id = overSpeedId,
-        expiration = FIVE_SECONDS
-    )
+    override fun playOverSpeed() {
+        if (tracker.shouldPlay(overSpeedId, PlayedAlertTracker.FIVE_SECONDS)) {
+            tracker.record(overSpeedId)
+            enqueueSound(Sound.OverSpeed)
+        }
+        tracker.cleanup()
+    }
 
     override fun playIncident(id: String, mapEventType: MapEventType) {
         val incidentSound = when (mapEventType) {
@@ -43,13 +40,24 @@ abstract class SharedSoundController : SoundController {
             MapEventType.Unsupported -> null
         } ?: return
 
-        if (isAlertAlreadyPlayed(id)) return
+        if (!tracker.shouldPlay(id)) return
 
-        playSound(sound = incidentSound, id = id)
+        tracker.record(id)
+        enqueueSound(incidentSound)
+        tracker.cleanup()
     }
 
     override fun playCameraLimit(id: String, speedLimit: Int, cameraType: CameraType) {
-        if (isAlertAlreadyPlayed(id)) return
+        if (!tracker.shouldPlay(id)) return
+
+        val cameraSound = when (cameraType) {
+            CameraType.StationaryCamera -> Sound.StationaryCamera
+            CameraType.MobileCamera -> Sound.MobileCamera
+            CameraType.MediumSpeedCamera -> Sound.MediumSpeedCamera
+        }
+
+        tracker.record(id)
+        enqueueSound(cameraSound)
 
         val speedLimitSound = when (speedLimit) {
             40 -> Sound.SpeedLimit40
@@ -63,54 +71,14 @@ abstract class SharedSoundController : SoundController {
             120 -> Sound.SpeedLimit120
             else -> null
         }
-        val cameraSound = when (cameraType) {
-            CameraType.StationaryCamera -> Sound.StationaryCamera
-            CameraType.MobileCamera -> Sound.MobileCamera
-            CameraType.MediumSpeedCamera -> Sound.MediumSpeedCamera
+        speedLimitSound?.let {
+            val speedLimitId = "camera_$id"
+            if (tracker.shouldPlay(speedLimitId)) {
+                tracker.record(speedLimitId)
+                enqueueSound(it)
+            }
         }
 
-        playSound(sound = cameraSound, id = id)
-        speedLimitSound?.run { playSound(sound = this, id = "camera_$id") }
-    }
-
-    private fun playSound(
-        sound: Sound,
-        id: String = Uuid.random(),
-        expiration: Long = FIVE_MINUTES
-    ) {
-        val currentTimeMillis = currentTimeMillis
-        val item = soundHistory[id]
-
-        if (item == null) {
-            soundHistory[id] = SoundTimeStamp(sound = sound, timestamp = currentTimeMillis)
-            enqueueSound(sound)
-        } else if (currentTimeMillis - item.timestamp > expiration) {
-            soundHistory[id] = item.copy(timestamp = currentTimeMillis)
-            enqueueSound(sound)
-        }
-
-        invalidateOldSounds()
-    }
-
-    private fun isAlertAlreadyPlayed(alertId: String): Boolean {
-        val lastPlayed = soundHistory[alertId]
-        return lastPlayed != null && currentTimeMillis - lastPlayed.timestamp < FIVE_MINUTES
-    }
-
-    private fun invalidateOldSounds() {
-        val currentTime = currentTimeMillis
-
-        soundHistory.entries.removeAll { currentTime - it.value.timestamp > THIRTY_MINUTES }
-    }
-
-    private data class SoundTimeStamp(
-        val sound: Sound,
-        val timestamp: Long
-    )
-
-    companion object {
-        val FIVE_SECONDS = 5.seconds.inWholeMilliseconds
-        val FIVE_MINUTES = 5.minutes.inWholeMilliseconds
-        val THIRTY_MINUTES = 30.minutes.inWholeMilliseconds
+        tracker.cleanup()
     }
 }

--- a/kmp/features/guidance/src/commonMain/kotlin/com/egoriku/grodnoroads/guidance/screen/sound/SoundController.kt
+++ b/kmp/features/guidance/src/commonMain/kotlin/com/egoriku/grodnoroads/guidance/screen/sound/SoundController.kt
@@ -20,7 +20,6 @@ interface SoundController {
 
 abstract class SharedSoundController : SoundController {
     private val soundHistory = mutableMapOf<String, SoundTimeStamp>()
-    private val playedAlertIds = mutableMapOf<String, Long>()
     private val overSpeedId = Uuid.random()
 
     private val currentTimeMillis: Long
@@ -94,21 +93,14 @@ abstract class SharedSoundController : SoundController {
     }
 
     private fun isAlertAlreadyPlayed(alertId: String): Boolean {
-        val currentTimeMillis = currentTimeMillis
-        val lastPlayed = playedAlertIds[alertId]
-        if (lastPlayed != null && currentTimeMillis - lastPlayed < FIVE_MINUTES) {
-            return true
-        }
-        playedAlertIds[alertId] = currentTimeMillis
-        invalidateOldSounds()
-        return false
+        val lastPlayed = soundHistory[alertId]
+        return lastPlayed != null && currentTimeMillis - lastPlayed.timestamp < FIVE_MINUTES
     }
 
     private fun invalidateOldSounds() {
         val currentTime = currentTimeMillis
 
         soundHistory.entries.removeAll { currentTime - it.value.timestamp > THIRTY_MINUTES }
-        playedAlertIds.entries.removeAll { currentTime - it.value > THIRTY_MINUTES }
     }
 
     private data class SoundTimeStamp(

--- a/kmp/features/guidance/src/commonMain/kotlin/com/egoriku/grodnoroads/guidance/screen/sound/SoundController.kt
+++ b/kmp/features/guidance/src/commonMain/kotlin/com/egoriku/grodnoroads/guidance/screen/sound/SoundController.kt
@@ -44,13 +44,13 @@ abstract class SharedSoundController : SoundController {
             MapEventType.Unsupported -> null
         } ?: return
 
-        if (!isAlertAlreadyPlayed(id)) return
+        if (isAlertAlreadyPlayed(id)) return
 
         playSound(sound = incidentSound, id = id)
     }
 
     override fun playCameraLimit(id: String, speedLimit: Int, cameraType: CameraType) {
-        if (!isAlertAlreadyPlayed(id)) return
+        if (isAlertAlreadyPlayed(id)) return
 
         val speedLimitSound = when (speedLimit) {
             40 -> Sound.SpeedLimit40
@@ -77,7 +77,7 @@ abstract class SharedSoundController : SoundController {
     private fun playSound(
         sound: Sound,
         id: String = Uuid.random(),
-        expiration: Long = FIVE_MINUTE
+        expiration: Long = FIVE_MINUTES
     ) {
         val currentTimeMillis = currentTimeMillis
         val item = soundHistory[id]
@@ -96,27 +96,19 @@ abstract class SharedSoundController : SoundController {
     private fun isAlertAlreadyPlayed(alertId: String): Boolean {
         val currentTimeMillis = currentTimeMillis
         val lastPlayed = playedAlertIds[alertId]
-        if (lastPlayed != null && currentTimeMillis - lastPlayed < FIVE_MINUTE) {
-            return false
+        if (lastPlayed != null && currentTimeMillis - lastPlayed < FIVE_MINUTES) {
+            return true
         }
         playedAlertIds[alertId] = currentTimeMillis
         invalidateOldSounds()
-        return true
+        return false
     }
 
     private fun invalidateOldSounds() {
         val currentTime = currentTimeMillis
-        val invalidSoundIds = soundHistory
-            .filterValues { currentTime - it.timestamp > THIRTY_MINUTES }
-            .keys
 
-        invalidSoundIds.forEach(soundHistory::remove)
-
-        val invalidAlertIds = playedAlertIds
-            .filterValues { currentTime - it > THIRTY_MINUTES }
-            .keys
-
-        invalidAlertIds.forEach(playedAlertIds::remove)
+        soundHistory.entries.removeAll { currentTime - it.value.timestamp > THIRTY_MINUTES }
+        playedAlertIds.entries.removeAll { currentTime - it.value > THIRTY_MINUTES }
     }
 
     private data class SoundTimeStamp(
@@ -126,7 +118,7 @@ abstract class SharedSoundController : SoundController {
 
     companion object {
         val FIVE_SECONDS = 5.seconds.inWholeMilliseconds
-        val FIVE_MINUTE = 5.minutes.inWholeMilliseconds
+        val FIVE_MINUTES = 5.minutes.inWholeMilliseconds
         val THIRTY_MINUTES = 30.minutes.inWholeMilliseconds
     }
 }

--- a/kmp/features/guidance/src/commonMain/kotlin/com/egoriku/grodnoroads/guidance/screen/sound/SoundController.kt
+++ b/kmp/features/guidance/src/commonMain/kotlin/com/egoriku/grodnoroads/guidance/screen/sound/SoundController.kt
@@ -23,10 +23,7 @@ abstract class SharedSoundController(
     abstract fun enqueueSound(sound: Sound)
 
     override fun playOverSpeed() {
-        if (tracker.shouldPlay(overSpeedId, PlayedAlertTracker.FIVE_SECONDS)) {
-            tracker.record(overSpeedId)
-            enqueueSound(Sound.OverSpeed)
-        }
+        playIfAllowed(overSpeedId, Sound.OverSpeed, PlayedAlertTracker.FIVE_SECONDS)
         tracker.cleanup()
     }
 
@@ -40,24 +37,18 @@ abstract class SharedSoundController(
             MapEventType.Unsupported -> null
         } ?: return
 
-        if (!tracker.shouldPlay(id)) return
-
-        tracker.record(id)
-        enqueueSound(incidentSound)
+        playIfAllowed(id, incidentSound)
         tracker.cleanup()
     }
 
     override fun playCameraLimit(id: String, speedLimit: Int, cameraType: CameraType) {
-        if (!tracker.shouldPlay(id)) return
-
         val cameraSound = when (cameraType) {
             CameraType.StationaryCamera -> Sound.StationaryCamera
             CameraType.MobileCamera -> Sound.MobileCamera
             CameraType.MediumSpeedCamera -> Sound.MediumSpeedCamera
         }
 
-        tracker.record(id)
-        enqueueSound(cameraSound)
+        playIfAllowed(id, cameraSound)
 
         val speedLimitSound = when (speedLimit) {
             40 -> Sound.SpeedLimit40
@@ -72,13 +63,20 @@ abstract class SharedSoundController(
             else -> null
         }
         speedLimitSound?.let {
-            val speedLimitId = "camera_$id"
-            if (tracker.shouldPlay(speedLimitId)) {
-                tracker.record(speedLimitId)
-                enqueueSound(it)
-            }
+            playIfAllowed("camera_$id", it)
         }
 
         tracker.cleanup()
+    }
+
+    private fun playIfAllowed(
+        id: String,
+        sound: Sound,
+        expiration: Long = PlayedAlertTracker.FIVE_MINUTES
+    ) {
+        if (tracker.shouldPlay(id, expiration)) {
+            tracker.record(id)
+            enqueueSound(sound)
+        }
     }
 }

--- a/kmp/features/guidance/src/commonTest/kotlin/com/egoriku/grodnoroads/guidance/screen/sound/PlayedAlertTrackerTest.kt
+++ b/kmp/features/guidance/src/commonTest/kotlin/com/egoriku/grodnoroads/guidance/screen/sound/PlayedAlertTrackerTest.kt
@@ -1,0 +1,90 @@
+package com.egoriku.grodnoroads.guidance.screen.sound
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PlayedAlertTrackerTest {
+
+    private var currentTime = 1000L
+    private val tracker = PlayedAlertTracker { currentTime }
+
+    @Test
+    fun `shouldPlay new alert returns true`() {
+        assertTrue(tracker.shouldPlay("alert_1"))
+    }
+
+    @Test
+    fun `shouldPlay recently played alert returns false`() {
+        tracker.record("alert_1")
+
+        assertFalse(tracker.shouldPlay("alert_1"))
+    }
+
+    @Test
+    fun `shouldPlay after default expiration returns true`() {
+        tracker.record("alert_1")
+
+        currentTime += PlayedAlertTracker.FIVE_MINUTES + 1
+
+        assertTrue(tracker.shouldPlay("alert_1"))
+    }
+
+    @Test
+    fun `shouldPlay with custom expiration`() {
+        val customExpiration = 10_000L
+        tracker.record("alert_1")
+
+        currentTime += customExpiration - 1
+        assertFalse(tracker.shouldPlay("alert_1", customExpiration))
+
+        currentTime += 2
+        assertTrue(tracker.shouldPlay("alert_1", customExpiration))
+    }
+
+    @Test
+    fun `shouldPlay different alerts are independent`() {
+        tracker.record("alert_1")
+
+        assertTrue(tracker.shouldPlay("alert_2"))
+    }
+
+    @Test
+    fun `cleanup removes old entries`() {
+        tracker.record("alert_1")
+        tracker.record("alert_2")
+
+        currentTime += PlayedAlertTracker.THIRTY_MINUTES + 1
+        tracker.cleanup()
+
+        assertEquals(0, tracker.size())
+    }
+
+    @Test
+    fun `cleanup keeps recent entries`() {
+        tracker.record("alert_1")
+
+        currentTime += PlayedAlertTracker.THIRTY_MINUTES - 1
+        tracker.cleanup()
+
+        assertEquals(1, tracker.size())
+    }
+
+    @Test
+    fun `record updates timestamp`() {
+        tracker.record("alert_1")
+        assertFalse(tracker.shouldPlay("alert_1"))
+
+        currentTime += PlayedAlertTracker.FIVE_MINUTES + 1
+        assertTrue(tracker.shouldPlay("alert_1"))
+    }
+
+    @Test
+    fun `shouldPlay with zero expiration always returns true for existing alert`() {
+        tracker.record("alert_1")
+
+        currentTime += 1
+        assertTrue(tracker.shouldPlay("alert_1", expiration = 0))
+    }
+}


### PR DESCRIPTION
Replace sound-type-based deduplication with alert-ID-based tracking. Old checkDuplicate() used a 30s window keyed by Sound type, which allowed the same camera alert to replay when the alerts list re-emitted with updated distance values.

New isAlertAlreadyPlayed() tracks by alert ID with a 5-minute cooldown, preventing duplicate playback regardless of how often the flow re-emits.