### PR TITLE
Extract layout module without Material dependency, move Spacer there

### DIFF
--- a/kmp/compose/foundation/layout/build.gradle.kts
+++ b/kmp/compose/foundation/layout/build.gradle.kts
@@ -6,17 +6,11 @@ plugins {
 }
 
 kotlin {
-    configureTargets(namespace = "com.egoriku.grodnoroads.foundation.uikit")
+    configureTargets(namespace = "com.egoriku.grodnoroads.foundation.layout")
 
     sourceSets {
         commonMain.dependencies {
-            implementation(projects.kmp.compose.foundation.icons)
-            api(projects.kmp.compose.foundation.core)
-            api(projects.kmp.compose.foundation.layout)
-            api(projects.kmp.compose.foundation.preview)
-
             api(libs.compose.foundation)
-            api(libs.compose.material3)
             api(libs.compose.runtime)
             api(libs.compose.ui)
         }

--- a/kmp/compose/foundation/layout/src/commonMain/kotlin/com/egoriku/grodnoroads/foundation/layout/Spacer.kt
+++ b/kmp/compose/foundation/layout/src/commonMain/kotlin/com/egoriku/grodnoroads/foundation/layout/Spacer.kt
@@ -1,4 +1,4 @@
-package com.egoriku.grodnoroads.foundation.uikit
+package com.egoriku.grodnoroads.foundation.layout
 
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.RowScope
@@ -9,15 +9,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 
-// TODO: rename to Spacer
 @Composable
-fun ColumnScope.VerticalSpacer(
+fun ColumnScope.Spacer(
     dp: Dp,
     modifier: Modifier = Modifier
 ) = Spacer(modifier = modifier.height(dp))
 
 @Composable
-fun RowScope.HorizontalSpacer(
+fun RowScope.Spacer(
     dp: Dp,
     modifier: Modifier = Modifier
 ) = Spacer(modifier = modifier.width(dp))

--- a/kmp/compose/foundation/uikit/src/commonMain/kotlin/com/egoriku/grodnoroads/foundation/uikit/listitem/CheckBoxListItem.kt
+++ b/kmp/compose/foundation/uikit/src/commonMain/kotlin/com/egoriku/grodnoroads/foundation/uikit/listitem/CheckBoxListItem.kt
@@ -22,9 +22,9 @@ import androidx.compose.ui.unit.dp
 import com.egoriku.grodnoroads.foundation.core.rememberMutableState
 import com.egoriku.grodnoroads.foundation.icons.GrodnoRoads
 import com.egoriku.grodnoroads.foundation.icons.colored.MobileCamera
+import com.egoriku.grodnoroads.foundation.layout.Spacer
 import com.egoriku.grodnoroads.foundation.preview.GrodnoRoadsM3ThemePreview
 import com.egoriku.grodnoroads.foundation.preview.PreviewGrodnoRoads
-import com.egoriku.grodnoroads.foundation.uikit.HorizontalSpacer
 import com.egoriku.grodnoroads.foundation.uikit.dynamic.Checkbox
 
 @Composable
@@ -61,7 +61,7 @@ fun CheckBoxListItem(
             style = MaterialTheme.typography.bodyMedium
         )
         if (imageVector != null) {
-            HorizontalSpacer(12.dp)
+            Spacer(12.dp)
             Image(
                 modifier = Modifier.size(iconSize),
                 imageVector = imageVector,

--- a/kmp/compose/foundation/uikit/src/commonMain/kotlin/com/egoriku/grodnoroads/foundation/uikit/listitem/RadioButtonListItem.kt
+++ b/kmp/compose/foundation/uikit/src/commonMain/kotlin/com/egoriku/grodnoroads/foundation/uikit/listitem/RadioButtonListItem.kt
@@ -15,11 +15,11 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import com.egoriku.grodnoroads.foundation.core.rememberMutableState
+import com.egoriku.grodnoroads.foundation.layout.Spacer
 import com.egoriku.grodnoroads.foundation.preview.GrodnoRoadsM3ThemePreview
 import com.egoriku.grodnoroads.foundation.preview.PlatformPreviewProvider
 import com.egoriku.grodnoroads.foundation.preview.PreviewGrodnoRoadsDarkLight
 import com.egoriku.grodnoroads.foundation.theme.Platform
-import com.egoriku.grodnoroads.foundation.uikit.HorizontalSpacer
 import com.egoriku.grodnoroads.foundation.uikit.dynamic.DynamicRadioButton
 
 @Composable
@@ -50,7 +50,7 @@ fun RadioButtonListItem(
             text = text,
             style = MaterialTheme.typography.titleMedium
         )
-        HorizontalSpacer(12.dp)
+        Spacer(12.dp)
     }
 }
 

--- a/kmp/features/appSettings/src/commonMain/kotlin/com/egoriku/grodnoroads/appsettings/screen/AppSettingsScreen.kt
+++ b/kmp/features/appSettings/src/commonMain/kotlin/com/egoriku/grodnoroads/appsettings/screen/AppSettingsScreen.kt
@@ -45,9 +45,9 @@ import com.egoriku.grodnoroads.foundation.icons.outlined.Changelog
 import com.egoriku.grodnoroads.foundation.icons.outlined.Faq
 import com.egoriku.grodnoroads.foundation.icons.outlined.Map
 import com.egoriku.grodnoroads.foundation.icons.outlined.NotificationBadge
+import com.egoriku.grodnoroads.foundation.layout.WeightSpacer
 import com.egoriku.grodnoroads.foundation.preview.GrodnoRoadsM3ThemePreview
 import com.egoriku.grodnoroads.foundation.preview.PreviewGrodnoRoads
-import com.egoriku.grodnoroads.foundation.uikit.WeightSpacer
 import com.egoriku.grodnoroads.shared.components.AppBuildConfig
 import com.egoriku.grodnoroads.shared.models.Page
 import org.jetbrains.compose.resources.stringResource

--- a/kmp/features/eventReporting/src/commonMain/kotlin/com/egoriku/grodnoroads/eventreporting/screen/EventReportingScreen.kt
+++ b/kmp/features/eventReporting/src/commonMain/kotlin/com/egoriku/grodnoroads/eventreporting/screen/EventReportingScreen.kt
@@ -30,9 +30,9 @@ import com.egoriku.grodnoroads.eventreporting.screen.ui.foundation.SelectableOpt
 import com.egoriku.grodnoroads.foundation.common.ui.bottomsheet.BasicModalBottomSheet
 import com.egoriku.grodnoroads.foundation.common.ui.bottomsheet.rememberSheetCloseBehaviour
 import com.egoriku.grodnoroads.foundation.core.rememberMutableState
+import com.egoriku.grodnoroads.foundation.layout.Spacer
 import com.egoriku.grodnoroads.foundation.preview.GrodnoRoadsM3ThemePreview
 import com.egoriku.grodnoroads.foundation.preview.PreviewGrodnoRoads
-import com.egoriku.grodnoroads.foundation.uikit.VerticalSpacer
 import com.egoriku.grodnoroads.shared.models.reporting.ReportParams
 import org.jetbrains.compose.resources.stringResource
 
@@ -123,12 +123,12 @@ private fun ReportingUi(
             text = stringResource(Res.string.reporting_header),
             style = MaterialTheme.typography.headlineSmall
         )
-        VerticalSpacer(16.dp)
+        Spacer(16.dp)
         ReportingTypesCarousel(
             currentType = reportType,
             onTypeChange = onReportTypeChange
         )
-        VerticalSpacer(16.dp)
+        Spacer(16.dp)
 
         when (reportType) {
             ReportType.MobileCamera -> {

--- a/kmp/features/eventReporting/src/commonMain/kotlin/com/egoriku/grodnoroads/eventreporting/screen/ui/foundation/SelectableOptions.kt
+++ b/kmp/features/eventReporting/src/commonMain/kotlin/com/egoriku/grodnoroads/eventreporting/screen/ui/foundation/SelectableOptions.kt
@@ -12,9 +12,9 @@ import androidx.compose.ui.unit.dp
 import com.egoriku.grodnoroads.eventreporting.domain.Reporting
 import com.egoriku.grodnoroads.eventreporting.screen.ui.util.toStringResource
 import com.egoriku.grodnoroads.foundation.core.rememberMutableState
+import com.egoriku.grodnoroads.foundation.layout.Spacer
 import com.egoriku.grodnoroads.foundation.preview.GrodnoRoadsM3ThemePreview
 import com.egoriku.grodnoroads.foundation.preview.PreviewGrodnoRoads
-import com.egoriku.grodnoroads.foundation.uikit.VerticalSpacer
 import com.egoriku.grodnoroads.foundation.uikit.listitem.RadioButtonListItem
 import com.egoriku.grodnoroads.shared.models.reporting.ReportParams
 import org.jetbrains.compose.resources.stringResource
@@ -51,7 +51,7 @@ internal fun ColumnScope.SelectableOptions(
             }
         )
     }
-    VerticalSpacer(8.dp)
+    Spacer(8.dp)
 }
 
 @PreviewGrodnoRoads

--- a/kmp/features/guidance/src/commonMain/kotlin/com/egoriku/grodnoroads/guidance/screen/ui/CameraInfo.kt
+++ b/kmp/features/guidance/src/commonMain/kotlin/com/egoriku/grodnoroads/guidance/screen/ui/CameraInfo.kt
@@ -35,12 +35,11 @@ import com.egoriku.grodnoroads.foundation.icons.colored.MobileCameraBold
 import com.egoriku.grodnoroads.foundation.icons.colored.StationaryCameraBold
 import com.egoriku.grodnoroads.foundation.icons.outlined.Car
 import com.egoriku.grodnoroads.foundation.icons.outlined.Truck
+import com.egoriku.grodnoroads.foundation.layout.Spacer
 import com.egoriku.grodnoroads.foundation.preview.GrodnoRoadsM3ThemePreview
 import com.egoriku.grodnoroads.foundation.preview.PreviewGrodnoRoads
 import com.egoriku.grodnoroads.foundation.theme.Red
 import com.egoriku.grodnoroads.foundation.uikit.DisabledText
-import com.egoriku.grodnoroads.foundation.uikit.HorizontalSpacer
-import com.egoriku.grodnoroads.foundation.uikit.VerticalSpacer
 import com.egoriku.grodnoroads.foundation.uikit.button.SecondaryButton
 import com.egoriku.grodnoroads.guidance.domain.model.MapEvent
 import com.egoriku.grodnoroads.guidance.domain.model.MapEvent.Camera.MediumSpeedCamera
@@ -70,7 +69,7 @@ internal fun CameraInfo(
                 is MobileCamera -> Res.string.alerts_mobile_camera
             }
         )
-        VerticalSpacer(32.dp)
+        Spacer(32.dp)
     }
 }
 
@@ -87,7 +86,7 @@ private fun Info(
                 imageVector = imageVector,
                 contentDescription = null
             )
-            HorizontalSpacer(16.dp)
+            Spacer(16.dp)
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                 Text(
                     text = camera.name.ifEmpty { stringResource(Res.string.camera_info_stub_title) },
@@ -106,7 +105,7 @@ private fun Info(
                 )
             }
         }
-        VerticalSpacer(16.dp)
+        Spacer(16.dp)
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically
@@ -124,7 +123,7 @@ private fun Info(
         }
 
         if (FeatureFlags.REPORT_CAMERA_PROBLEMS_ENABLED) {
-            VerticalSpacer(24.dp)
+            Spacer(24.dp)
             SecondaryButton(
                 modifier = Modifier.fillMaxWidth(),
                 text = stringResource(Res.string.camera_info_report),
@@ -149,7 +148,7 @@ private fun SpeedLimitGroup(
             imageVector = imageVector,
             contentDescription = null
         )
-        HorizontalSpacer(18.dp)
+        Spacer(18.dp)
         SpeedLimit(value = speed)
     }
 }

--- a/kmp/features/guidance/src/commonMain/kotlin/com/egoriku/grodnoroads/guidance/screen/ui/mode/DefaultOverlay.kt
+++ b/kmp/features/guidance/src/commonMain/kotlin/com/egoriku/grodnoroads/guidance/screen/ui/mode/DefaultOverlay.kt
@@ -46,9 +46,9 @@ import com.egoriku.grodnoroads.foundation.core.isMediumScreenWidth
 import com.egoriku.grodnoroads.foundation.core.rememberMutableState
 import com.egoriku.grodnoroads.foundation.icons.GrodnoRoads
 import com.egoriku.grodnoroads.foundation.icons.outlined.More
+import com.egoriku.grodnoroads.foundation.layout.Spacer
 import com.egoriku.grodnoroads.foundation.preview.GrodnoRoadsM3ThemePreview
 import com.egoriku.grodnoroads.foundation.preview.PreviewGrodnoRoadsDarkLight
-import com.egoriku.grodnoroads.foundation.uikit.VerticalSpacer
 import com.egoriku.grodnoroads.foundation.uikit.button.PrimaryInverseCircleButton
 import com.egoriku.grodnoroads.foundation.uikit.button.common.Size
 import com.egoriku.grodnoroads.guidance.domain.model.Alert
@@ -295,7 +295,7 @@ private fun DefaultOverlayPreview() = GrodnoRoadsM3ThemePreview {
             onOpenQuickSettings = {}
         )
         HorizontalDivider()
-        VerticalSpacer(8.dp)
+        Spacer(8.dp)
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -312,6 +312,6 @@ private fun DefaultOverlayPreview() = GrodnoRoadsM3ThemePreview {
                 Text(text = "Toggle Mode")
             }
         }
-        VerticalSpacer(8.dp)
+        Spacer(8.dp)
     }
 }

--- a/kmp/features/guidance/src/commonMain/kotlin/com/egoriku/grodnoroads/guidance/screen/ui/mode/drive/alerts/CameraAlert.kt
+++ b/kmp/features/guidance/src/commonMain/kotlin/com/egoriku/grodnoroads/guidance/screen/ui/mode/drive/alerts/CameraAlert.kt
@@ -26,9 +26,9 @@ import com.egoriku.grodnoroads.foundation.icons.GrodnoRoads
 import com.egoriku.grodnoroads.foundation.icons.colored.MediumSpeedCamera
 import com.egoriku.grodnoroads.foundation.icons.colored.MobileCamera
 import com.egoriku.grodnoroads.foundation.icons.colored.StationaryCamera
+import com.egoriku.grodnoroads.foundation.layout.Spacer
 import com.egoriku.grodnoroads.foundation.preview.GrodnoRoadsM3ThemePreview
 import com.egoriku.grodnoroads.foundation.preview.PreviewGrodnoRoads
-import com.egoriku.grodnoroads.foundation.uikit.VerticalSpacer
 import com.egoriku.grodnoroads.guidance.screen.ui.foundation.SpeedLimitSign
 import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
@@ -64,7 +64,7 @@ fun CameraAlert(
                         text = title,
                         style = MaterialTheme.typography.bodyLarge
                     )
-                    VerticalSpacer(4.dp)
+                    Spacer(4.dp)
                     Text(
                         modifier = Modifier.fillMaxWidth(),
                         textAlign = TextAlign.Center,

--- a/kmp/features/intro/src/commonMain/kotlin/com/egoriku/grodnoroads/cityselector/ui/ChooseCityPage.kt
+++ b/kmp/features/intro/src/commonMain/kotlin/com/egoriku/grodnoroads/cityselector/ui/ChooseCityPage.kt
@@ -16,7 +16,7 @@ import com.egoriku.grodnoroads.compose.resources.city_selector_choose_city
 import com.egoriku.grodnoroads.extensions.Collator
 import com.egoriku.grodnoroads.foundation.common.ui.lazycolumn.Group
 import com.egoriku.grodnoroads.foundation.common.ui.lazycolumn.GroupedSingleChoiceLazyColumn
-import com.egoriku.grodnoroads.foundation.uikit.VerticalSpacer
+import com.egoriku.grodnoroads.foundation.layout.Spacer
 import com.egoriku.grodnoroads.foundation.uikit.listitem.RadioButtonListItem
 import com.egoriku.grodnoroads.shared.persistent.toStringResource
 import org.jetbrains.compose.resources.stringResource
@@ -48,7 +48,7 @@ internal fun ChooseCityPage(
             style = MaterialTheme.typography.displaySmall,
             textAlign = TextAlign.Center
         )
-        VerticalSpacer(24.dp)
+        Spacer(24.dp)
         GroupedSingleChoiceLazyColumn(
             modifier = Modifier.fillMaxWidth(),
             groups = displayGroups,

--- a/kmp/features/intro/src/commonMain/kotlin/com/egoriku/grodnoroads/onboarding/OnboardingScreen.kt
+++ b/kmp/features/intro/src/commonMain/kotlin/com/egoriku/grodnoroads/onboarding/OnboardingScreen.kt
@@ -31,8 +31,7 @@ import com.egoriku.grodnoroads.foundation.icons.GrodnoRoads
 import com.egoriku.grodnoroads.foundation.icons.outlined.ArrowLeft
 import com.egoriku.grodnoroads.foundation.icons.outlined.ArrowRight
 import com.egoriku.grodnoroads.foundation.icons.outlined.Check
-import com.egoriku.grodnoroads.foundation.uikit.HorizontalSpacer
-import com.egoriku.grodnoroads.foundation.uikit.VerticalSpacer
+import com.egoriku.grodnoroads.foundation.layout.Spacer
 import com.egoriku.grodnoroads.foundation.uikit.button.PrimaryCircleButton
 import com.egoriku.grodnoroads.foundation.uikit.button.SecondaryCircleButton
 import com.egoriku.grodnoroads.foundation.uikit.button.common.Size
@@ -88,12 +87,12 @@ private fun OnboardingUi(
                 )
             }
         }
-        VerticalSpacer(24.dp)
+        Spacer(24.dp)
         Footer(
             pagerState = pagerState,
             onComplete = completeOnboarding
         )
-        VerticalSpacer(24.dp)
+        Spacer(24.dp)
     }
 }
 
@@ -122,7 +121,7 @@ private fun Footer(
                         }
                     }
                 )
-                HorizontalSpacer(16.dp)
+                Spacer(16.dp)
             }
         }
         if (pagerState.currentPage != pagerState.pageCount - 1) {

--- a/kmp/features/intro/src/commonMain/kotlin/com/egoriku/grodnoroads/onboarding/ui/InfographicPage.kt
+++ b/kmp/features/intro/src/commonMain/kotlin/com/egoriku/grodnoroads/onboarding/ui/InfographicPage.kt
@@ -10,7 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.egoriku.grodnoroads.foundation.uikit.VerticalSpacer
+import com.egoriku.grodnoroads.foundation.layout.Spacer
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.painterResource
 
@@ -34,7 +34,7 @@ internal fun InfographicPage(
                 style = MaterialTheme.typography.displaySmall,
                 textAlign = TextAlign.Center
             )
-            VerticalSpacer(16.dp)
+            Spacer(16.dp)
             Text(
                 text = description,
                 style = MaterialTheme.typography.bodyLarge

--- a/kmp/features/quickSettings/src/commonMain/kotlin/com/egoriku/grodnoroads/quicksettings/screen/ui/QuickSettingsContent.kt
+++ b/kmp/features/quickSettings/src/commonMain/kotlin/com/egoriku/grodnoroads/quicksettings/screen/ui/QuickSettingsContent.kt
@@ -36,11 +36,11 @@ import com.egoriku.grodnoroads.foundation.icons.outlined.Filter
 import com.egoriku.grodnoroads.foundation.icons.outlined.Moon
 import com.egoriku.grodnoroads.foundation.icons.outlined.Notification
 import com.egoriku.grodnoroads.foundation.icons.outlined.TrafficJam
+import com.egoriku.grodnoroads.foundation.layout.Spacer
+import com.egoriku.grodnoroads.foundation.layout.WeightSpacer
 import com.egoriku.grodnoroads.foundation.preview.GrodnoRoadsM3ThemePreview
 import com.egoriku.grodnoroads.foundation.preview.PreviewGrodnoRoads
 import com.egoriku.grodnoroads.foundation.uikit.FilterChip
-import com.egoriku.grodnoroads.foundation.uikit.VerticalSpacer
-import com.egoriku.grodnoroads.foundation.uikit.WeightSpacer
 import com.egoriku.grodnoroads.foundation.uikit.dynamic.Switch
 import com.egoriku.grodnoroads.quicksettings.domain.model.QuickSettingsState
 import com.egoriku.grodnoroads.quicksettings.domain.store.QuickSettingsPref
@@ -64,36 +64,36 @@ internal fun QuickSettingsContent(
             text = stringResource(Res.string.quick_settings_header),
             style = MaterialTheme.typography.headlineSmall
         )
-        VerticalSpacer(26.dp)
+        Spacer(26.dp)
         AppearanceSection(
             appTheme = quickSettingsState.appTheme,
             onChange = onChange
         )
-        VerticalSpacer(24.dp)
+        Spacer(24.dp)
         FilteringSection(
             markerFiltering = quickSettingsState.markerFiltering,
             onChange = onChange
         )
-        VerticalSpacer(24.dp)
+        Spacer(24.dp)
         MapTypeSection(
             mapTypeAppearance = quickSettingsState.mapTypeAppearance,
             onChange = onChange
         )
-        VerticalSpacer(16.dp)
+        Spacer(16.dp)
         SwitchSetting(
             imageVector = GrodnoRoads.Outlined.Notification,
             name = stringResource(Res.string.quick_settings_voice_alerts),
             checked = quickSettingsState.voiceAlerts.enabled,
             onCheckedChange = { onChange(quickSettingsState.voiceAlerts.copy(enabled = it)) }
         )
-        VerticalSpacer(16.dp)
+        Spacer(16.dp)
         SwitchSetting(
             imageVector = GrodnoRoads.Outlined.TrafficJam,
             name = stringResource(Res.string.quick_settings_traffic_conditions),
             checked = quickSettingsState.trafficJamOnMap.isShow,
             onCheckedChange = { onChange(quickSettingsState.trafficJamOnMap.copy(isShow = it)) }
         )
-        VerticalSpacer(32.dp)
+        Spacer(32.dp)
     }
 }
 

--- a/kmp/features/settings/appearance/src/commonMain/kotlin/com/egoriku/grodnoroads/settings/appearance/screen/AppearanceScreen.kt
+++ b/kmp/features/settings/appearance/src/commonMain/kotlin/com/egoriku/grodnoroads/settings/appearance/screen/AppearanceScreen.kt
@@ -30,10 +30,10 @@ import com.egoriku.grodnoroads.foundation.core.HorizontalScrollableRow
 import com.egoriku.grodnoroads.foundation.icons.GrodnoRoads
 import com.egoriku.grodnoroads.foundation.icons.outlined.Brightness
 import com.egoriku.grodnoroads.foundation.icons.outlined.Moon
+import com.egoriku.grodnoroads.foundation.layout.Spacer
 import com.egoriku.grodnoroads.foundation.preview.GrodnoRoadsM3ThemePreview
 import com.egoriku.grodnoroads.foundation.preview.PreviewGrodnoRoadsDarkLight
 import com.egoriku.grodnoroads.foundation.uikit.FilterChip
-import com.egoriku.grodnoroads.foundation.uikit.VerticalSpacer
 import com.egoriku.grodnoroads.foundation.uikit.listitem.MoreActionListItem
 import com.egoriku.grodnoroads.foundation.uikit.listitem.SwitchListItem
 import com.egoriku.grodnoroads.settings.appearance.domain.component.AppearanceComponent
@@ -87,9 +87,9 @@ fun AppearanceScreen(
             SettingsSectionHeader(title = stringResource(Res.string.settings_category_main))
             AppThemeSection(state = state, onModify = appearanceComponent::modify)
             LanguageSection(state = state, onModify = appearanceComponent::modify)
-            VerticalSpacer(16.dp)
+            Spacer(16.dp)
             MapTypeAppearanceSection(state = state, onModify = appearanceComponent::update)
-            VerticalSpacer(16.dp)
+            Spacer(16.dp)
             KeepScreenOnSettings(state = state, onModify = appearanceComponent::update)
         }
     }

--- a/kmp/features/settings/changelog/src/commonMain/kotlin/com/egoriku/grodnoroads/settings/changelog/screen/ui/ChangelogItem.kt
+++ b/kmp/features/settings/changelog/src/commonMain/kotlin/com/egoriku/grodnoroads/settings/changelog/screen/ui/ChangelogItem.kt
@@ -14,10 +14,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.egoriku.grodnoroads.extensions.LoremIpsum
+import com.egoriku.grodnoroads.foundation.layout.Spacer
 import com.egoriku.grodnoroads.foundation.preview.GrodnoRoadsM3ThemePreview
 import com.egoriku.grodnoroads.foundation.preview.PreviewGrodnoRoadsDarkLight
 import com.egoriku.grodnoroads.foundation.uikit.DisabledText
-import com.egoriku.grodnoroads.foundation.uikit.VerticalSpacer
 import com.egoriku.grodnoroads.settings.changelog.domain.model.ChangelogEntry
 
 private val latestReleaseEmojis = listOf("🔥", "⭐", "🎉", "✨", "🚀", "💎")
@@ -49,7 +49,7 @@ internal fun ChangelogItem(
                 text = release.releaseDate,
                 style = MaterialTheme.typography.labelSmall
             )
-            VerticalSpacer(4.dp)
+            Spacer(4.dp)
             Text(
                 text = release.notes,
                 style = MaterialTheme.typography.bodyMedium

--- a/kmp/features/settings/debugTools/src/commonMain/kotlin/com/egoriku/grodnoroads/settings/debugtools/DebugToolsScreen.kt
+++ b/kmp/features/settings/debugTools/src/commonMain/kotlin/com/egoriku/grodnoroads/settings/debugtools/DebugToolsScreen.kt
@@ -40,11 +40,11 @@ import com.egoriku.grodnoroads.foundation.icons.GrodnoRoads
 import com.egoriku.grodnoroads.foundation.icons.filled.Edit
 import com.egoriku.grodnoroads.foundation.icons.outlined.Appearance
 import com.egoriku.grodnoroads.foundation.icons.outlined.Moon
+import com.egoriku.grodnoroads.foundation.layout.Spacer
 import com.egoriku.grodnoroads.foundation.theme.GrodnoRoadsM3Theme
 import com.egoriku.grodnoroads.foundation.theme.LocalPlatform
 import com.egoriku.grodnoroads.foundation.theme.Platform
 import com.egoriku.grodnoroads.foundation.theme.Platform.Android
-import com.egoriku.grodnoroads.foundation.uikit.VerticalSpacer
 import com.egoriku.grodnoroads.settings.debugtools.domain.DebugToolsComponent
 import com.egoriku.grodnoroads.settings.debugtools.ui.datastore.DataStoreEdit
 import com.egoriku.grodnoroads.settings.debugtools.ui.palette.Material3Palette
@@ -93,7 +93,7 @@ fun DebugToolsScreen(
                         .padding(horizontal = 16.dp)
                         .padding(it)
                 ) {
-                    VerticalSpacer(8.dp)
+                    Spacer(8.dp)
                     AnimatedVisibility(visible = scrollState.isScrollingUp()) {
                         Column {
                             TopActions(
@@ -102,14 +102,14 @@ fun DebugToolsScreen(
                                 onChangeDarkTheme = { isDarkTheme = !isDarkTheme },
                                 onShowSpecialEvent = { specialEventType = it }
                             )
-                            VerticalSpacer(16.dp)
+                            Spacer(16.dp)
                         }
                     }
                     PlatformSegmentedRow(
                         current = platform,
                         onPlatformChange = { platform = it }
                     )
-                    VerticalSpacer(4.dp)
+                    Spacer(4.dp)
                     UiDemoList(modifier = Modifier.verticalScroll(scrollState))
                 }
             }

--- a/kmp/features/settings/debugTools/src/commonMain/kotlin/com/egoriku/grodnoroads/settings/debugtools/ui/uikit/common/UIKitDemoContainer.kt
+++ b/kmp/features/settings/debugTools/src/commonMain/kotlin/com/egoriku/grodnoroads/settings/debugtools/ui/uikit/common/UIKitDemoContainer.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.egoriku.grodnoroads.foundation.uikit.VerticalSpacer
+import com.egoriku.grodnoroads.foundation.layout.Spacer
 
 @Composable
 fun UIKitDemoContainer(
@@ -32,7 +32,7 @@ fun UIKitDemoContainer(
             text = name,
             style = MaterialTheme.typography.titleMedium
         )
-        VerticalSpacer(8.dp)
+        Spacer(8.dp)
         Column(modifier = Modifier.padding(paddingValues)) {
             content()
         }

--- a/kmp/features/settings/debugTools/src/commonMain/kotlin/com/egoriku/grodnoroads/settings/debugtools/ui/uikit/demo/DemoCheckbox.kt
+++ b/kmp/features/settings/debugTools/src/commonMain/kotlin/com/egoriku/grodnoroads/settings/debugtools/ui/uikit/demo/DemoCheckbox.kt
@@ -6,9 +6,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.egoriku.grodnoroads.foundation.core.rememberMutableState
+import com.egoriku.grodnoroads.foundation.layout.WeightSpacer
 import com.egoriku.grodnoroads.foundation.preview.GrodnoRoadsM3ThemePreview
 import com.egoriku.grodnoroads.foundation.preview.PreviewGrodnoRoadsDarkLight
-import com.egoriku.grodnoroads.foundation.uikit.WeightSpacer
 import com.egoriku.grodnoroads.foundation.uikit.dynamic.Checkbox
 import com.egoriku.grodnoroads.settings.debugtools.ui.uikit.common.UIKitDemoContainer
 

--- a/kmp/features/settings/debugTools/src/commonMain/kotlin/com/egoriku/grodnoroads/settings/debugtools/ui/uikit/demo/DemoNavigationRail.kt
+++ b/kmp/features/settings/debugTools/src/commonMain/kotlin/com/egoriku/grodnoroads/settings/debugtools/ui/uikit/demo/DemoNavigationRail.kt
@@ -15,11 +15,11 @@ import com.egoriku.grodnoroads.foundation.core.rememberMutableState
 import com.egoriku.grodnoroads.foundation.icons.GrodnoRoads
 import com.egoriku.grodnoroads.foundation.icons.outlined.Map
 import com.egoriku.grodnoroads.foundation.icons.outlined.Settings
+import com.egoriku.grodnoroads.foundation.layout.WeightSpacer
 import com.egoriku.grodnoroads.foundation.preview.GrodnoRoadsM3ThemePreview
 import com.egoriku.grodnoroads.foundation.preview.PreviewGrodnoRoadsDarkLight
 import com.egoriku.grodnoroads.foundation.uikit.NavigationRail
 import com.egoriku.grodnoroads.foundation.uikit.NavigationRailItem
-import com.egoriku.grodnoroads.foundation.uikit.WeightSpacer
 import com.egoriku.grodnoroads.settings.debugtools.ui.uikit.common.UIKitDemoContainer
 
 @Composable

--- a/kmp/features/settings/debugTools/src/commonMain/kotlin/com/egoriku/grodnoroads/settings/debugtools/ui/uikit/demo/DemoRadioButton.kt
+++ b/kmp/features/settings/debugTools/src/commonMain/kotlin/com/egoriku/grodnoroads/settings/debugtools/ui/uikit/demo/DemoRadioButton.kt
@@ -8,9 +8,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.egoriku.grodnoroads.foundation.core.rememberMutableState
+import com.egoriku.grodnoroads.foundation.layout.WeightSpacer
 import com.egoriku.grodnoroads.foundation.preview.GrodnoRoadsM3ThemePreview
 import com.egoriku.grodnoroads.foundation.preview.PreviewGrodnoRoadsDarkLight
-import com.egoriku.grodnoroads.foundation.uikit.WeightSpacer
 import com.egoriku.grodnoroads.foundation.uikit.dynamic.DynamicRadioButton
 import com.egoriku.grodnoroads.settings.debugtools.ui.uikit.common.UIKitDemoContainer
 

--- a/kmp/features/settings/debugTools/src/commonMain/kotlin/com/egoriku/grodnoroads/settings/debugtools/ui/uikit/demo/DemoSwitch.kt
+++ b/kmp/features/settings/debugTools/src/commonMain/kotlin/com/egoriku/grodnoroads/settings/debugtools/ui/uikit/demo/DemoSwitch.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.egoriku.grodnoroads.foundation.core.rememberMutableState
-import com.egoriku.grodnoroads.foundation.uikit.WeightSpacer
+import com.egoriku.grodnoroads.foundation.layout.WeightSpacer
 import com.egoriku.grodnoroads.foundation.uikit.dynamic.Switch
 import com.egoriku.grodnoroads.settings.debugtools.ui.uikit.common.UIKitDemoContainer
 

--- a/kmp/features/settings/debugTools/src/commonMain/kotlin/com/egoriku/grodnoroads/settings/debugtools/ui/uikit/demo/DemoTriStateCheckbox.kt
+++ b/kmp/features/settings/debugTools/src/commonMain/kotlin/com/egoriku/grodnoroads/settings/debugtools/ui/uikit/demo/DemoTriStateCheckbox.kt
@@ -8,9 +8,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.state.ToggleableState
 import com.egoriku.grodnoroads.foundation.core.rememberMutableState
+import com.egoriku.grodnoroads.foundation.layout.WeightSpacer
 import com.egoriku.grodnoroads.foundation.preview.GrodnoRoadsM3ThemePreview
 import com.egoriku.grodnoroads.foundation.preview.PreviewGrodnoRoadsDarkLight
-import com.egoriku.grodnoroads.foundation.uikit.WeightSpacer
 import com.egoriku.grodnoroads.foundation.uikit.dynamic.TriStateCheckbox
 import com.egoriku.grodnoroads.settings.debugtools.ui.uikit.common.UIKitDemoContainer
 

--- a/kmp/features/specialEventReminder/src/commonMain/kotlin/com/egoriku/grodnoroads/specialevent/screen/SpecialEventDialog.kt
+++ b/kmp/features/specialEventReminder/src/commonMain/kotlin/com/egoriku/grodnoroads/specialevent/screen/SpecialEventDialog.kt
@@ -25,9 +25,9 @@ import com.egoriku.grodnoroads.compose.resources.ok
 import com.egoriku.grodnoroads.foundation.common.ui.dialog.DialogContent
 import com.egoriku.grodnoroads.foundation.common.ui.dialog.content.DialogButton
 import com.egoriku.grodnoroads.foundation.core.rememberMutableState
+import com.egoriku.grodnoroads.foundation.layout.Spacer
 import com.egoriku.grodnoroads.foundation.preview.GrodnoRoadsM3ThemePreview
 import com.egoriku.grodnoroads.foundation.preview.PreviewGrodnoRoadsDarkLight
-import com.egoriku.grodnoroads.foundation.uikit.VerticalSpacer
 import com.egoriku.grodnoroads.foundation.uikit.listitem.CheckBoxListItem
 import com.egoriku.grodnoroads.specialevent.domain.model.EventType
 import com.egoriku.grodnoroads.specialevent.domain.model.EventType.Autumn
@@ -74,7 +74,7 @@ private fun SpecialEventDialogContent(
     }
 
     DialogContent {
-        VerticalSpacer(16.dp)
+        Spacer(16.dp)
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(16.dp)
@@ -95,7 +95,7 @@ private fun SpecialEventDialogContent(
                 onCheckedChange = { dismissToday = it }
             )
         }
-        VerticalSpacer(8.dp)
+        Spacer(8.dp)
         HorizontalDivider()
         DialogButton(
             modifier = Modifier.fillMaxWidth(),

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -37,6 +37,7 @@ include(":app:android")
 
 include(":kmp:compose:common-ui")
 include(":kmp:compose:foundation:core")
+include(":kmp:compose:foundation:layout")
 include(":kmp:compose:foundation:preview")
 include(":kmp:compose:foundation:theme")
 include(":kmp:compose:foundation:uikit")


### PR DESCRIPTION
Spacer.kt only used compose.foundation APIs, so it didn't need to live in uikit (which depends on material3).